### PR TITLE
Correct the record on Pex features.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ their use case. (Hint: it might, or might not, be pychubby!)
 | Feature/Need                | pychubby                        | pex                                  | zipapp                         | PyInstaller / PyOxidizer                         |
 |-----------------------------|---------------------------------|--------------------------------------|--------------------------------|--------------------------------------------------|
 | Single-file distribution    | Yes (`.chub`)                   | Yes                                  | Yes (`.pyz`)                   | Yes (binary)                                     |
-| Includes Python interpreter | No - uses current environment   | Yes - bundled runtime                | No - uses host interpreter     | Yes - frozen binary                              |
+| Includes Python interpreter | No - uses current environment   | No - uses host interpeter            | No - uses host interpreter     | Yes - frozen binary                              |
+
 | Reproducible install        | Yes - exact wheel copies        | Yes - via PEX-locked deps            | Sometimes - zip structure      | No - binary blob                                 |
 | Works in venv/conda/sys env | Yes - pip into any target       | Somewhat (venv-only)                 | Yes - but ephemeral venv       | Yes – standalone embedded runtime (not reusable) |
 | Create a new venv           | Yes - ephemeral or persistent   | Yes - existing or new/ephemeral      | Yes - ephemeral                | No – uses frozen, internal environment           |
@@ -106,7 +107,7 @@ match, a partial fit, or better suited elsewhere.
 | Use Case / Scenario                              | pychubby  | pex        | zipapp    | PyInstaller / PyOxidizer |
 |--------------------------------------------------|-----------|------------|-----------|--------------------------|
 | Distribute a CLI/lib in one file                 | best fit  | best fit   | works     | overkill                 |
-| Ship sealed GUI/CLI to end users with no Python  | n/a       | n/a        | n/a       | best fit                 |
+| Ship sealed GUI/CLI to end users with no Python  | n/a       | best fit⁷  | n/a       | best fit                 |
 | Run directly from compressed archive             | works     | best fit   | best fit  | n/a                      |
 | Reproducible install without network             | best fit  | best fit   | possible¹ | works                    |
 | Install into *any* Python env (sys, venv, conda) | best fit  | venv-only² | best fit  | n/a                      |
@@ -127,6 +128,7 @@ Notes:
 4. Build-time only: PyOxidizer allows scripted setup during packaging, not at install time.
 5. Partial cross-platform: PEX artifacts must match target platforms; wheel compatibility can limit this.
 6. Planned feature: pychubby currently supports pip-based installs only. Conda support is on the potential roadmap.
+7. When using Pex `--scie {eager,lazy}` which produces a native executable that includes Python.
 
 So the point isn’t that any of these are "best" or "wrong" tools. They’re all
 excellent for the jobs they were built for. Pychubby simply covers a different

--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ their use case. (Hint: it might, or might not, be pychubby!)
 |-----------------------------|---------------------------------|--------------------------------------|--------------------------------|--------------------------------------------------|
 | Single-file distribution    | Yes (`.chub`)                   | Yes                                  | Yes (`.pyz`)                   | Yes (binary)                                     |
 | Includes Python interpreter | No - uses current environment   | No - uses host interpeter            | No - uses host interpreter     | Yes - frozen binary                              |
-
 | Reproducible install        | Yes - exact wheel copies        | Yes - via PEX-locked deps            | Sometimes - zip structure      | No - binary blob                                 |
 | Works in venv/conda/sys env | Yes - pip into any target       | Somewhat (venv-only)                 | Yes - but ephemeral venv       | Yes – standalone embedded runtime (not reusable) |
 | Create a new venv           | Yes - ephemeral or persistent   | Yes - existing or new/ephemeral      | Yes - ephemeral                | No – uses frozen, internal environment           |


### PR DESCRIPTION
This was mostly right except for 2 misconceptions:
1. Pex can use any interpreter on the host compatible with the contained wheels.
2. Pex has a `--scie` option that produces a scie, which is a native executable that includes a Python interpreter.

Another misconception I did not correct is the general conception about cross-platform artifacts. Pex supports creating a cross-platform artifact as a primary use case (Twitter wanted PEX files that could run on Mac and Linux even when they relied on platform-specific wheels).

Although I failed to build a chub, FWICT there is no way it can be cross platform unless the wheels it packages happen to be, i.e:, bug or my misuse aside, I can't see how this leads to a cross-platform .chub today:
```console
:; python -mvenv /tmp/example.venv
:; source /tmp/example.venv/bin/activate
:; pip install -q pychubby@git+https://github.com/Steve973/pychubby

:; pex3 download --intransitive numpy -d .
:; ls -1 numpy*
numpy-2.3.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl

:; rm -rf chub-build/
:; pychubby numpy-2.3.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
Traceback (most recent call last):
  File "/tmp/example.venv/bin/pychubby", line 7, in <module>
    sys.exit(main())
             ~~~~^^
  File "/tmp/example.venv/lib/python3.13/site-packages/pychubby/cli.py", line 68, in main
    build_chub(
    ~~~~~~~~~~^
        wheel_path=args.wheel,
        ^^^^^^^^^^^^^^^^^^^^^^
    ...<3 lines>...
        included_files=args.includes or [],
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        metadata=metadata)
        ^^^^^^^^^^^^^^^^^^
  File "/tmp/example.venv/lib/python3.13/site-packages/pychubby/packager.py", line 282, in build_chub
    validate_chub_structure(wheel_package_dir, post_install_scripts, included_files)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/example.venv/lib/python3.13/site-packages/pychubby/packager.py", line 208, in validate_chub_structure
    raise FileExistsError(
        f"Wheel package directory '{wheel_package_dir}' already exists. "
        "Each wheel must be added exactly once.")
FileExistsError: Wheel package directory '/home/jsirois/dev/Steve973/pychubby/chub-build/numpy-2.3.2' already exists. Each wheel must be added exactly once.
:; pwd
/home/jsirois/dev/Steve973/pychubby
```

That said, you _can_ build a cross-platform PEX:
```console
:; pex numpy --platform=macosx-11.0-x86_64-cp-313-cp313 --platform=linux-x86_64-cp-313-cp313 -o mac-and-linux-numpy.pex
:; zipinfo mac-and-linux-numpy.pex | grep METADATA
?rw-r--r--  2.0 unx     7423 b- defN 80-Jan-01 00:00 .deps/numpy-2.3.2-cp313-cp313-linux_x86_64.whl/numpy-2.3.2.dist-info/METADATA
?rw-r--r--  2.0 unx    62149 b- defN 80-Jan-01 00:00 .deps/numpy-2.3.2-cp313-cp313-macosx_10_13_x86_64.whl/numpy-2.3.2.dist-info/METADATA

# Pex will figure out the right platform-specific wheel to load given the current interpreter.
:; ./mac-and-linux-numpy.pex
Pex 2.52.0 hermetic environment with 1 requirement and 1 activated distribution.
Python 3.13.7 (main, Aug 15 2025, 11:40:50) [GCC 14.2.0] on linux
Type "help", "pex", "copyright", "credits" or "license" for more information.
>>> pex()
Running from PEX file: ./mac-and-linux-numpy.pex
Requirements:
  numpy
Activated Distributions:
  numpy-2.3.2-cp313-cp313-linux_x86_64.whl
>>> import numpy
>>> numpy.__file__
'/home/jsirois/.cache/pex/installed_wheels/0/b2acd530f2ebb160cd9d9b27b3685d75dadf03f106af55b0e25ed461d126916a/numpy-2.3.2-cp313-cp313-linux_x86_64.whl/numpy/__init__.py'
>>>
```